### PR TITLE
Add README and CLAUDE.md documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,48 @@
+# TBS (Travel Buddy Service)
+
+A MERN-stack travel-planning app: a React SPA frontend backed by an Express/MongoDB API. TBS is the consumer ("project-A") of the separate **DS-Service** backend, which it calls for LLM-backed trip planning and (eventually) destination/spot data.
+
+@../DS-Service/CLAUDE.md
+
+> **DS-Service is the upstream data source — check its API contract (linked above, under "## API Contract") before creating DB models or making API calls to it.** Field-name casing, response shapes, and auth requirements there are authoritative; don't guess or re-derive them from TBS's own conventions.
+
+This repo has two independent Node projects, each with its own `package.json`/`node_modules` — always `cd` into the relevant one before running scripts.
+
+## `Node/` — Express API backend
+
+Tech: Express, Mongoose, Passport (JWT strategy), bcryptjs, nodemailer, axios (for calling DS-Service).
+
+**Commands** (run from `TBS/Node/`):
+- `npm run dev` — `nodemon index.js` (auto-restart dev server)
+- `npm start` — `node index.js` (no reload)
+- No test script is defined.
+
+**Structure:**
+- `index.js` — app entry: Mongo connection, middleware, route mounting on port `process.env.PORT` (default 6666).
+- `APIs/` — route modules: `auth.js` (register/login/current-user/password reset), `dsservice.js` (proxies to DS-Service), `token.js`, `trip.js` (trip intake, mock itinerary generation, CRUD on trips).
+- `Config/` — `jwtgenerator.js` (mints access/refresh/DS-Service tokens), `passport.js` (JWT strategy setup).
+- `DB_Models/` — Mongoose schemas: `DB_User.js`, `DB_Trip.js`.
+- `Emails/` — nodemailer templates (welcome, confirmation, forgot/create password).
+- `Services/mockItinerary.js` — **placeholder** itinerary generator; fakes what a real DS-Service integration (`/datasourcing/sourcespots` + a not-yet-built day-by-day planner) will eventually do. See the comment at the top of that file and DS-Service's API contract before replacing it.
+- `Validation/` — plain-function request-body validators (`login.js`, `register.js`, `resetPassword.js`, `isEmpty.js`).
+
+**Conventions:**
+- Route handlers use `.then()/.catch()` (not async/await) throughout `APIs/auth.js` and `APIs/trip.js`.
+- DB model fields are PascalCase (`FirstName`, `Email`, `ResetToken`), matching DS-Service's convention — keep new fields consistent with this casing.
+- User-facing auth routes issue tokens via `generateAccessToken(user, 'auth' | 'refresh' | 'deepseek')` in `Config/jwtgenerator.js`. The `'deepseek'` usage is what signs the `token` field DS-Service expects (60s expiry, secret `DEEPSEEK_JWT_SECRET` — must match DS-Service's copy of the same secret).
+- Calls into DS-Service go through `axios` with the base URL `process.env.DS_SERVICE_BASEURL`; see `APIs/dsservice.js` for the current pattern (mint a `'deepseek'` token, attach it as `token` in the JSON body — not a header — then POST).
+
+**Env vars** (`Node/.env`): `PORT`, `MONGODB_URL`, `ACCESSSECRETE`, `REFRESHSECRETE`, `RESETSECRET`, `DEEPSEEK_JWT_SECRET`, `GD_MAP_JWT_SECRET`, `DS_SERVICE_BASEURL`.
+
+## `react-frontend/` — React SPA
+
+Tech: React 19, Redux Toolkit + Redux Thunk, React Router v6, MUI + Emotion, axios.
+
+**Commands** (run from `TBS/react-frontend/`):
+- `npm start` — dev server (`react-scripts start`), proxies API calls to `http://localhost:6666` (see `"proxy"` in `package.json` — i.e. the `Node/` backend above, not DS-Service directly)
+- `npm run build` — production build
+- `npm test` — CRA/Jest test runner (`react-scripts test`)
+
+**Structure:** standard Create React App layout — `src/actions`, `src/reducers`, `src/components`, `src/hooks`, `src/utils`, `src/store.js` (Redux store setup), `src/App.js`.
+
+**Conventions:** the frontend never talks to DS-Service directly — it goes through the `Node/` backend (`/dsservice/*`, `/trip/*` routes), which in turn calls DS-Service. If you're adding a UI feature that needs DS-Service data, the new/changed logic belongs in `Node/APIs/dsservice.js` (or a new route module) first, following DS-Service's contract, then wired up to the frontend through the existing proxy.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,91 @@
-# TBS
-Travel Buddy Service
+# TBS — Travel Buddy Service
+
+TBS is a MERN-stack travel-planning application. Users chat through a trip-intake flow, and the app builds out a day-by-day itinerary for their destination. It consists of a React single-page frontend backed by an Express/MongoDB API, which in turn calls the separate [DS-Service](https://github.com/itjinshan/DS-Service) backend for LLM-powered trip planning and destination data.
+
+## What it does
+
+- **User accounts** — registration, login, password reset, and JWT-based session auth.
+- **Trip intake** — a conversational flow that extracts trip details (destination, duration, travelers, budget) from user input.
+- **Itinerary generation** — builds a day-by-day itinerary for the trip.
+- **Trip storage** — saved trips are persisted per user and retrievable by ID.
+
+## Architecture
+
+This repo contains two independently run projects:
+
+| Directory | What it is |
+|---|---|
+| `Node/` | Express API: auth, trip intake/storage, and the integration point with DS-Service |
+| `react-frontend/` | React SPA — the user-facing app |
+
+The frontend talks only to the `Node/` backend; the `Node/` backend is the one that calls out to DS-Service. See the root [`CLAUDE.md`](../CLAUDE.md) for how the two services relate.
+
+## Tech stack
+
+- **Backend:** Express, Mongoose, Passport (JWT strategy), bcryptjs, nodemailer, axios
+- **Frontend:** React 19, Redux Toolkit, React Router, MUI
+
+## Getting started
+
+Each directory has its own dependencies and must be set up separately.
+
+### Backend (`Node/`)
+
+```bash
+cd Node
+npm install
+```
+
+Create a `.env` file in `Node/`:
+
+```
+PORT=6666
+MONGODB_URL=<your MongoDB connection string>
+ACCESSSECRETE=<JWT access token secret>
+REFRESHSECRETE=<JWT refresh token secret>
+RESETSECRET=<password reset token secret>
+DEEPSEEK_JWT_SECRET=<shared secret with DS-Service>
+GD_MAP_JWT_SECRET=<maps API secret>
+DS_SERVICE_BASEURL=<base URL of the DS-Service instance to call>
+```
+
+Run the server:
+
+```bash
+npm run dev   # auto-restarting dev server
+npm start     # single run, no reload
+```
+
+The API listens on `PORT` (default `6666`).
+
+### Frontend (`react-frontend/`)
+
+```bash
+cd react-frontend
+npm install
+npm start
+```
+
+The dev server proxies API requests to `http://localhost:6666` (the `Node/` backend above), so the backend should be running first.
+
+Other available scripts: `npm run build` (production build), `npm test` (test runner).
+
+## Project structure
+
+```
+Node/
+  index.js           App entry point
+  APIs/               Route handlers (auth, trip, DS-Service proxy)
+  Config/             JWT generation, Passport setup
+  DB_Models/          Mongoose schemas (User, Trip)
+  Emails/             Transactional email templates
+  Services/           Itinerary generation logic
+  Validation/         Request validation helpers
+
+react-frontend/
+  src/
+    actions/          Redux actions
+    reducers/          Redux reducers
+    components/        UI components
+    hooks/              Custom React hooks
+```


### PR DESCRIPTION
## Summary
- Add a proper README.md covering what TBS does, the frontend/backend split, tech stack, and setup instructions for each half
- Add CLAUDE.md documenting both projects' structure and conventions, with an import of DS-Service's API contract and a note to check it before touching DB models or DS-Service calls

## Test plan
- [ ] Review README for accuracy against current setup steps
- [ ] Review DS-Service integration notes for accuracy