### PR TITLE
Persistent Itinerary-page chatbot for targeted itinerary edits

### DIFF
--- a/Node/APIs/trip.js
+++ b/Node/APIs/trip.js
@@ -5,7 +5,7 @@ require('../Config/passport')(passport);
 var axios = require('axios');
 var Trip = require('../DB_Models/DB_Trip');
 var { generateFallbackItinerary } = require('../Services/fallbackItinerary');
-var { arrangeIntoDays, SPOTS_PER_DAY, SPOT_REQUEST_BUFFER_MULTIPLIER } = require('../Services/itineraryPlanner');
+var { arrangeIntoDays, replaceSpotInDay, SPOTS_PER_DAY, SPOT_REQUEST_BUFFER_MULTIPLIER } = require('../Services/itineraryPlanner');
 var spotSourcing = require('../Services/spotSourcing');
 var nluExtraction = require('../Services/nluExtraction');
 var amapPlaces = require('../Services/amapPlaces');
@@ -26,6 +26,12 @@ var STAGES = {
     SUGGEST_ACCOMMODATION: 'suggest_accommodation',
     READY: 'ready'
 };
+
+// Conversation stages for the Itinerary page's post-generation refinement
+// chatbot (POST /trip/refine, below) — a separate, simpler stage machine
+// from STAGES above, since this conversation starts fresh once an itinerary
+// already exists rather than building one up field by field.
+var REFINE_STAGES = { CONFIRM: 'confirm', EDITING: 'editing', DONE: 'done' };
 
 var OTHER_PREF_QUESTIONS = {
     duration: "How many days are you planning to travel?",
@@ -353,6 +359,88 @@ router.post('/generate', function (req, res) {
             console.error('Real itinerary generation failed, falling back:', err.message);
             res.json(generateFallbackItinerary(tripBrief));
         });
+});
+
+// Targeted edits to an already-generated itinerary, from the Itinerary
+// page's persistent refinement chatbot — see CLAUDE.md, "Redesign the
+// Itinerary page around a persistent chatbot". Fully stateless, same
+// pattern as /intake and /generate: the client resends the full itinerary
+// object every turn (the same shape /generate returns) rather than this
+// route addressing a saved Mongo `_id` — nothing here touches the DB, so
+// DB_Trip.js's Days/Spots sub-schemas being `{ _id: false }` never comes
+// into play. Persistence stays the existing separate, explicit saveTrip()
+// action, which naturally picks up whatever edits happened first.
+router.post('/refine', function (req, res) {
+    var message = req.body.message || '';
+    var itinerary = req.body.itinerary;
+    var stage = req.body.refinementStage || REFINE_STAGES.CONFIRM;
+
+    if (!itinerary || !Array.isArray(itinerary.days)) {
+        return res.status(400).json({ message: 'Missing required field: itinerary' });
+    }
+
+    function respond(reply, nextStage, updatedItinerary) {
+        var payload = { reply: reply, stage: nextStage };
+        if (updatedItinerary) payload.itinerary = updatedItinerary;
+        res.json(payload);
+    }
+    function respondError(err) {
+        console.error('Trip refine error:', err);
+        res.status(502).json({ message: 'Something went wrong while processing that — please try again.' });
+    }
+
+    switch (stage) {
+        case REFINE_STAGES.CONFIRM: {
+            nluExtraction.extractYesNo(message, 'whether the traveler wants to change anything about the generated itinerary')
+                .then(function (choice) {
+                    if (choice === 'yes') {
+                        respond('Sure — what would you like to change? (e.g. "swap day 2\'s museum for something more outdoorsy")', REFINE_STAGES.EDITING);
+                    } else if (choice === 'no') {
+                        // Extension point for CLAUDE.md's logged Bug
+                        // ("Accommodation suggestions are prompted during
+                        // intake, before the itinerary exists"): once that
+                        // fix lands, a "no" here should move straight into
+                        // settling accommodation (search near the generated
+                        // spots' centroid, present results, let the
+                        // traveler pick) instead of just ending the
+                        // conversation. Deliberately left as a comment
+                        // hook — out of scope for this PR, see that Bug's
+                        // own fix design.
+                        respond('Great — enjoy your trip!', REFINE_STAGES.DONE);
+                    } else {
+                        respond('Just to confirm — would you like to change anything about this plan? (yes/no)', REFINE_STAGES.CONFIRM);
+                    }
+                })
+                .catch(respondError);
+            break;
+        }
+
+        case REFINE_STAGES.EDITING:
+        case REFINE_STAGES.DONE: {
+            // Any message once past the initial confirm — including one sent
+            // after previously answering "no" — is treated as an edit
+            // instruction; a traveler changing their mind later is the same
+            // operation "yes" up front would have led to.
+            nluExtraction.extractSpotSwap(message, 'identifying which day, which existing spot, and what kind of replacement the traveler wants for their itinerary')
+                .then(function (swap) {
+                    if (!swap.dayNumber) {
+                        return respond('Which day is this for, and what would you like changed? (e.g. "day 2, swap the museum for something more outdoorsy")', REFINE_STAGES.EDITING);
+                    }
+                    return replaceSpotInDay(itinerary, swap.dayNumber, swap.targetSpotHint, swap.replacementCategory)
+                        .then(function (result) {
+                            if (!result.ok) {
+                                return respond(result.reply, REFINE_STAGES.EDITING);
+                            }
+                            respond(result.reply + ' Anything else you\'d like to change?', REFINE_STAGES.EDITING, result.itinerary);
+                        });
+                })
+                .catch(respondError);
+            break;
+        }
+
+        default:
+            respond('Want to change anything about this plan? (yes/no)', REFINE_STAGES.CONFIRM);
+    }
 });
 
 router.post('/', passport.authenticate('jwt', { session: false }), function (req, res) {

--- a/Node/Services/itineraryPlanner.js
+++ b/Node/Services/itineraryPlanner.js
@@ -34,6 +34,7 @@
 // available and still fits the remaining budget.
 
 const spotPhotos = require('./spotPhotos');
+const spotSourcing = require('./spotSourcing');
 
 // Three vacation-pace tiers a traveler can pick during intake (see
 // APIs/trip.js's OTHER_PREF_FIELDS/OTHER_PREF_QUESTIONS and the "Pace" chip
@@ -309,4 +310,99 @@ async function arrangeIntoDays(spots, duration, accommodation, pace, transportMo
     }));
 }
 
-module.exports = { arrangeIntoDays, SPOTS_PER_DAY, SPOT_REQUEST_BUFFER_MULTIPLIER };
+// How many candidates to over-fetch from DS-Service when sourcing a
+// replacement spot for a swap — /datasourcing/sourcespots has no
+// exclude-list/category-bias parameter (see DS-Service's CLAUDE.md API
+// Contract), so this pulls the widest pool the contract allows and
+// filters/excludes client-side instead. 40 is that contract's own
+// documented minCount cap.
+const REPLACEMENT_OVERFETCH_MIN_COUNT = 40;
+
+// Finds the spot in `daySpots` a free-text hint most likely refers to — an
+// exact/partial name match first (either direction, so "museum" matches
+// "National Museum of China" and vice versa), falling back to a category
+// match (hint "the museum" against Category "museum"). A day with exactly
+// one spot has no ambiguity to resolve even with no hint at all; otherwise
+// no match returns -1 rather than guessing.
+function findTargetSpotIndex(daySpots, hint) {
+    if (!hint) return daySpots.length === 1 ? 0 : -1;
+    const lowerHint = hint.toLowerCase();
+    const byName = daySpots.findIndex((s) => {
+        const lowerName = s.Name.toLowerCase();
+        return lowerName.includes(lowerHint) || lowerHint.includes(lowerName);
+    });
+    if (byName !== -1) return byName;
+    return daySpots.findIndex((s) => s.Category && lowerHint.includes(s.Category.toLowerCase()));
+}
+
+// Sources a replacement spot for a swap: over-fetches the destination's spot
+// pool, excludes anything already anywhere in the itinerary (by name), and
+// prefers the requested category if one was given — falling back to any
+// non-duplicate if the category has no match, rather than failing outright.
+// Highest-rated candidate wins.
+async function findReplacementSpot(destination, usedNamesLower, replacementCategory) {
+    const pool = await spotSourcing.sourceSpots(destination, REPLACEMENT_OVERFETCH_MIN_COUNT);
+    const candidates = pool.filter((s) => !usedNamesLower.has(s.Name.toLowerCase()));
+
+    const categoryMatched = replacementCategory ? candidates.filter((s) => s.Category === replacementCategory) : [];
+    const pickFrom = categoryMatched.length ? categoryMatched : candidates;
+    if (!pickFrom.length) return null;
+
+    pickFrom.sort((a, b) => (b.Rating || 0) - (a.Rating || 0));
+    const chosen = pickFrom[0];
+
+    const photo = await spotPhotos.findSpotPhoto(chosen.Name, chosen.City).catch(() => null);
+    return Object.assign({}, chosen, { Photo: photo || PLACEHOLDER_PHOTOS[0] });
+}
+
+// Applies a single-spot swap within one day — the one architecturally cheap
+// edit operation this file supports. Deliberately does NOT touch
+// buildGreedyTour/splitIntoDays: those run one continuous, order-dependent
+// pass over every spot in the trip at once (see this file's header comment),
+// so "regenerate day N" isn't a well-defined operation without reshuffling
+// every other day too. A swap only needs buildRoute() recomputed for the
+// one affected day — already pure and day-local, no dependency on other
+// days. Operates purely on the in-memory itinerary object the caller
+// already holds (the same shape arrangeIntoDays/`/trip/generate` produce) —
+// no Mongo access, so DB_Trip.js's `Days`/`Spots` sub-schemas being
+// `{ _id: false }` (no stable per-day/per-spot ids) never comes into play.
+async function replaceSpotInDay(itinerary, dayNumber, targetSpotHint, replacementCategory) {
+    const days = itinerary.days || [];
+    const dayIndex = days.findIndex((d) => d.DayNumber === dayNumber);
+    if (dayIndex === -1) {
+        return { ok: false, reply: `I couldn't find day ${dayNumber} in this itinerary — this trip only has ${days.length} day${days.length === 1 ? '' : 's'}.` };
+    }
+
+    const day = days[dayIndex];
+    const spotIndex = findTargetSpotIndex(day.Spots, targetSpotHint);
+    if (spotIndex === -1) {
+        return { ok: false, reply: `I couldn't tell which spot on day ${dayNumber} you meant — could you name it more specifically?` };
+    }
+
+    const targetSpot = day.Spots[spotIndex];
+    const usedNames = new Set(days.flatMap((d) => d.Spots.map((s) => s.Name.toLowerCase())));
+
+    const replacement = await findReplacementSpot(itinerary.destination, usedNames, replacementCategory);
+    if (!replacement) {
+        return { ok: false, reply: `I couldn't find a good replacement for ${targetSpot.Name} right now — try a different category, or try again in a moment.` };
+    }
+
+    const newDaySpots = day.Spots.slice();
+    newDaySpots[spotIndex] = replacement;
+
+    const newDay = Object.assign({}, day, {
+        Spots: newDaySpots,
+        Route: buildRoute(newDaySpots, dayIndex, days.length, itinerary.accommodation, itinerary.arrivalPoint, itinerary.departurePoint)
+    });
+
+    const newDays = days.slice();
+    newDays[dayIndex] = newDay;
+
+    return {
+        ok: true,
+        reply: `Swapped ${targetSpot.Name} for ${replacement.Name} on day ${dayNumber}.`,
+        itinerary: Object.assign({}, itinerary, { days: newDays })
+    };
+}
+
+module.exports = { arrangeIntoDays, replaceSpotInDay, SPOTS_PER_DAY, SPOT_REQUEST_BUFFER_MULTIPLIER };

--- a/Node/Services/nluExtraction.js
+++ b/Node/Services/nluExtraction.js
@@ -74,4 +74,23 @@ function extractYesNo(message, context) {
     });
 }
 
-module.exports = { extractDestination, extractOtherPrefs, extractYesNo };
+// Parses a free-text itinerary-edit instruction (e.g. "swap day 2's museum
+// for something more outdoorsy") into which day, which existing spot
+// (a name/description hint, not necessarily an exact match), and what
+// category of replacement the traveler wants. No rule-based fallback here —
+// there's no regex equivalent for this shape of extraction — a DS-Service
+// failure just resolves to {}, letting the caller re-ask instead of guessing.
+function extractSpotSwap(message, context) {
+    return callExtract(message, ['dayNumber', 'targetSpotHint', 'replacementCategory'], context).then(function (extracted) {
+        var result = {};
+        if (isPresent(extracted.dayNumber)) result.dayNumber = Number(extracted.dayNumber);
+        if (isPresent(extracted.targetSpotHint)) result.targetSpotHint = extracted.targetSpotHint;
+        if (isPresent(extracted.replacementCategory)) result.replacementCategory = extracted.replacementCategory;
+        return result;
+    }).catch(function (err) {
+        console.error('NLU spot-swap extraction failed:', err.message);
+        return {};
+    });
+}
+
+module.exports = { extractDestination, extractOtherPrefs, extractYesNo, extractSpotSwap };

--- a/react-frontend/src/App.js
+++ b/react-frontend/src/App.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
+import { BrowserRouter as Router, Route, Routes, useLocation } from "react-router-dom";
 import PrivateRoute from "./utils/PrivateRoute";
 
 import NavBar from "./components/layout/Navbar"
@@ -28,6 +28,16 @@ import Itinerary from "./components/itinerary/Itinerary"
 import { Provider } from "react-redux";
 import { store } from "./store";
 
+// Superseded by the docked ItineraryChatPanel on the Itinerary page — avoid
+// two overlapping chat entry points (the floating "Need help?" bubble sits
+// bottom-right, same corner a right-docked chat panel would occupy) on the
+// same page. See components/itinerary/ItineraryChatPanel.js.
+const GlobalLLMChatBot = () => {
+  const location = useLocation();
+  if (location.pathname === '/itinerary') return null;
+  return <LLMChatBot />;
+};
+
 
 // App class
 //
@@ -51,7 +61,7 @@ export default class App extends Component {
               </Routes>
             </div>
             <Footer />
-            <LLMChatBot />
+            <GlobalLLMChatBot />
             </div>
         </Router>
       </Provider>

--- a/react-frontend/src/actions/tripAction.js
+++ b/react-frontend/src/actions/tripAction.js
@@ -4,7 +4,13 @@ import {
     SET_ITINERARY_LOADING,
     SET_ITINERARY,
     TRIP_ERRORS,
-    RESET_TRIP
+    RESET_TRIP,
+    ADD_REFINEMENT_MESSAGE,
+    SET_REFINEMENT_STAGE,
+    SET_REFINEMENT_LOADING,
+    REFINEMENT_ERRORS,
+    RESET_REFINEMENT,
+    UPDATE_ITINERARY
 } from "./types";
 import axios from "axios";
 
@@ -40,6 +46,10 @@ export const updateTripBriefField = (field, value) => ({
 
 export const generateItinerary = () => (dispatch, getState) => {
     const { tripBrief } = getState().trip;
+    // Clear any leftover refinement conversation from a previously
+    // generated itinerary — otherwise a stale chat could carry over onto a
+    // brand new trip if the user regenerates without ever navigating away.
+    dispatch({ type: RESET_REFINEMENT });
     dispatch({ type: SET_ITINERARY_LOADING, payload: true });
 
     return axios
@@ -81,6 +91,45 @@ export const saveTrip = () => (dispatch, getState) => {
                 payload: err.response ? err.response.data : { message: "An error occurred" }
             });
             throw err;
+        });
+};
+
+// Opens the Itinerary page's refinement conversation — a static, local-only
+// opening turn (the "confirm" half of the confirm-then-modify flow) needing
+// no backend round-trip; only the traveler's yes/no answer hits the server.
+export const startRefinementConversation = () => (dispatch) => {
+    dispatch({ type: ADD_REFINEMENT_MESSAGE, payload: { text: 'Want to change anything about this plan? (yes/no)', sender: 'bot' } });
+    dispatch({ type: SET_REFINEMENT_STAGE, payload: 'confirm' });
+};
+
+// One turn of the post-generation refinement chat. Same shape as
+// sendIntakeMessage above, but against the separate refinement state (see
+// tripReducer.js) and POST /trip/refine, which is fully stateless like
+// /trip/intake — the client resends the current itinerary and stage every
+// turn rather than the backend addressing a saved trip.
+export const sendRefinementMessage = (message) => (dispatch, getState) => {
+    dispatch({ type: ADD_REFINEMENT_MESSAGE, payload: { text: message, sender: 'user' } });
+    dispatch({ type: SET_REFINEMENT_LOADING, payload: true });
+
+    const { itinerary, refinementStage } = getState().trip;
+
+    return axios
+        .post('/trip/refine', { message, itinerary, refinementStage })
+        .then(res => {
+            const { reply, stage, itinerary: updatedItinerary } = res.data;
+            if (updatedItinerary) {
+                dispatch({ type: UPDATE_ITINERARY, payload: updatedItinerary });
+            }
+            dispatch({ type: ADD_REFINEMENT_MESSAGE, payload: { text: reply, sender: 'bot' } });
+            dispatch({ type: SET_REFINEMENT_STAGE, payload: stage });
+            dispatch({ type: SET_REFINEMENT_LOADING, payload: false });
+        })
+        .catch(err => {
+            dispatch({
+                type: REFINEMENT_ERRORS,
+                payload: err.response ? err.response.data : { message: "An error occurred" }
+            });
+            dispatch({ type: SET_REFINEMENT_LOADING, payload: false });
         });
 };
 

--- a/react-frontend/src/actions/types.js
+++ b/react-frontend/src/actions/types.js
@@ -45,3 +45,15 @@ export const SET_ITINERARY_LOADING = "SET_ITINERARY_LOADING";
 export const SET_ITINERARY = "SET_ITINERARY";
 export const TRIP_ERRORS = "TRIP_ERRORS";
 export const RESET_TRIP = "RESET_TRIP";
+
+// ITINERARY-PAGE REFINEMENT CHAT — a separate conversation/stage machine
+// from trip intake above, so it gets its own message list/loading/error
+// fields rather than reusing ADD_TRIP_MESSAGE/SET_ITINERARY_LOADING/
+// TRIP_ERRORS (which would interleave the two conversations if the user
+// ever navigated back to `/` mid-refinement).
+export const ADD_REFINEMENT_MESSAGE = "ADD_REFINEMENT_MESSAGE";
+export const SET_REFINEMENT_STAGE = "SET_REFINEMENT_STAGE";
+export const SET_REFINEMENT_LOADING = "SET_REFINEMENT_LOADING";
+export const REFINEMENT_ERRORS = "REFINEMENT_ERRORS";
+export const RESET_REFINEMENT = "RESET_REFINEMENT";
+export const UPDATE_ITINERARY = "UPDATE_ITINERARY";

--- a/react-frontend/src/components/itinerary/Itinerary.css
+++ b/react-frontend/src/components/itinerary/Itinerary.css
@@ -1,6 +1,12 @@
-.container {
+.itinerary-page {
   display: flex;
   width: 100vw;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.container {
+  display: flex;
   height: 100vh;
   position: relative;
   overflow: hidden;

--- a/react-frontend/src/components/itinerary/Itinerary.js
+++ b/react-frontend/src/components/itinerary/Itinerary.js
@@ -7,6 +7,7 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import withRouter from "../../utils/withRouter";
 import { saveTrip } from "../../actions/tripAction";
+import ItineraryChatPanel from './ItineraryChatPanel';
 import './Itinerary.css';
 // fallback photos, keyed by the placeholder `Photo` value the backend
 // assigns when a real per-spot photo lookup (Services/spotPhotos.js) found
@@ -15,6 +16,12 @@ import HawaiiWall from "../../images/hawaii-wall.jpg";
 import KyotoWall from "../../images/Kyoto-wall.jpg";
 import NYWall from "../../images/ny-wall.jpg";
 import ShanghaiWall from "../../images/Shanghai-wall.jpg";
+
+// Kept in sync with ItineraryChatPanel.css's .itin-chat-panel.open/.collapsed
+// widths — the container below is shrunk by exactly this much so the two
+// never overlap or gap.
+const CHAT_PANEL_WIDTH = 380;
+const CHAT_PANEL_COLLAPSED_WIDTH = 56;
 
 const PLACEHOLDER_PHOTOS = {
   hawaii: HawaiiWall,
@@ -68,6 +75,17 @@ const Itinerary = ({ auth }) => {
   const geolocationRef = useRef(null);
 
   const [markers, setMarkers] = useState(() => spotsToMarkers(itinerary));
+  const [chatOpen, setChatOpen] = useState(true);
+
+  // Keeps the map's markers in sync with `itinerary` itself, not just the
+  // mount-time snapshot above — needed now that POST /trip/refine (via the
+  // Itinerary-page chat panel) can mutate `itinerary` in place while this
+  // page stays mounted. Without this, a post-swap itinerary would update
+  // the day-list cards (read directly from the itinerary selector) but
+  // leave stale map pins.
+  useEffect(() => {
+    setMarkers(spotsToMarkers(itinerary));
+  }, [itinerary]);
 
   // Initialize map when AMap is loaded
   useEffect(() => {
@@ -291,7 +309,12 @@ const Itinerary = ({ auth }) => {
   }
 
   return (
-    <div className="container" ref={containerRef}>
+    <div className="itinerary-page">
+    <div
+      className="container"
+      ref={containerRef}
+      style={{ width: `calc(100vw - ${chatOpen ? CHAT_PANEL_WIDTH : CHAT_PANEL_COLLAPSED_WIDTH}px)` }}
+    >
       {/* Left Panel - Day-by-day itinerary */}
       <div className="left-panel" style={{ width: `${splitRatio}%` }}>
         <div className="day-list">
@@ -369,6 +392,8 @@ const Itinerary = ({ auth }) => {
           </>
         )}
       </div>
+    </div>
+    <ItineraryChatPanel open={chatOpen} onToggle={() => setChatOpen((o) => !o)} />
     </div>
   );
 };

--- a/react-frontend/src/components/itinerary/ItineraryChatPanel.css
+++ b/react-frontend/src/components/itinerary/ItineraryChatPanel.css
@@ -1,0 +1,129 @@
+.itin-chat-panel {
+  height: 100vh;
+  flex-shrink: 0;
+  border-left: 1px solid #e8eaed;
+  background: #fff;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  transition: width 0.2s ease;
+}
+
+.itin-chat-panel.open {
+  width: 380px;
+}
+
+.itin-chat-panel.collapsed {
+  width: 56px;
+  align-items: center;
+}
+
+.itin-chat-toggle {
+  position: absolute;
+  top: 0.75rem;
+  left: 0.75rem;
+  border: none;
+  background: transparent;
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  color: #5f6368;
+  padding: 0.4rem;
+  border-radius: 6px;
+}
+
+.itin-chat-toggle:hover {
+  background: #f1f3f4;
+}
+
+.itin-chat-panel.collapsed .itin-chat-toggle {
+  position: static;
+  margin-top: 0.75rem;
+}
+
+.itin-chat-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  padding: 3rem 1.25rem 1rem;
+}
+
+.itin-chat-title {
+  margin-bottom: 0.75rem;
+  color: #202124;
+}
+
+.itin-chat-messages {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.itin-chat-messages .itin-chat-message {
+  display: flex;
+  margin-bottom: 0.6rem;
+}
+
+.itin-chat-messages .itin-chat-message.user {
+  justify-content: flex-end;
+}
+
+.itin-chat-messages .itin-chat-message-content {
+  max-width: 80%;
+  padding: 0.6rem 1rem;
+  border-radius: 14px;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  white-space: pre-line;
+}
+
+.itin-chat-messages .itin-chat-message.bot .itin-chat-message-content {
+  background: #e8eaed;
+  color: #202124;
+}
+
+.itin-chat-messages .itin-chat-message.user .itin-chat-message-content {
+  background: #4285f4;
+  color: white;
+}
+
+.itin-chat-input-form {
+  display: flex;
+  border: 1px solid #e8eaed;
+  border-radius: 24px;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.itin-chat-input-form input {
+  flex: 1;
+  border: none;
+  padding: 0.7rem 1rem;
+  font-size: 0.9rem;
+  outline: none;
+  min-width: 0;
+}
+
+.itin-chat-input-form button {
+  border: none;
+  background: #4285f4;
+  color: white;
+  padding: 0 1.3rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.itin-chat-input-form button:disabled {
+  background: #9aa0a6;
+  cursor: not-allowed;
+}
+
+.itin-chat-error {
+  color: #ea4335;
+  font-size: 0.85rem;
+  margin-top: 0.5rem;
+  flex-shrink: 0;
+}

--- a/react-frontend/src/components/itinerary/ItineraryChatPanel.js
+++ b/react-frontend/src/components/itinerary/ItineraryChatPanel.js
@@ -1,0 +1,78 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { useTranslation } from 'react-i18next';
+import { sendRefinementMessage, startRefinementConversation } from '../../actions/tripAction';
+import './ItineraryChatPanel.css';
+
+// Persistent chat panel for the Itinerary page — a dedicated, always-visible
+// column (open by default), not a floating help bubble. Reuses
+// TripIntakePanel.js's message-list/input-form/auto-scroll pattern under
+// its own `itin-chat-*` class names (kept separate rather than shared,
+// since TBS has no CSS Modules and the two chat surfaces are independent
+// components with independent styling needs).
+const ItineraryChatPanel = ({ open, onToggle }) => {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const { refinementMessages, isRefining, refinementError } = useSelector((state) => state.trip);
+  const [inputValue, setInputValue] = useState('');
+  const messagesRef = useRef(null);
+
+  // Opens the confirm-then-modify conversation once, the first time this
+  // panel mounts with nothing in it yet — a static local message, no
+  // backend round-trip.
+  useEffect(() => {
+    if (refinementMessages.length === 0) {
+      dispatch(startRefinementConversation());
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Same scrollTop-direct technique as TripIntakePanel.js, not
+  // scrollIntoView() — keeps the scroll confined to this panel's own
+  // message log instead of dragging the whole page.
+  useEffect(() => {
+    if (open && messagesRef.current) {
+      messagesRef.current.scrollTop = messagesRef.current.scrollHeight;
+    }
+  }, [refinementMessages, open]);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!inputValue.trim() || isRefining) return;
+    dispatch(sendRefinementMessage(inputValue.trim()));
+    setInputValue('');
+  };
+
+  return (
+    <div className={`itin-chat-panel ${open ? 'open' : 'collapsed'}`}>
+      <button type="button" className="itin-chat-toggle" onClick={onToggle} aria-label={t('itinerary.chat.toggle')}>
+        {open ? '›' : '💬'}
+      </button>
+      {open && (
+        <div className="itin-chat-body">
+          <h4 className="itin-chat-title">{t('itinerary.chat.title')}</h4>
+          <div className="itin-chat-messages" ref={messagesRef}>
+            {refinementMessages.map((m) => (
+              <div key={m.id} className={`itin-chat-message ${m.sender}`}>
+                <div className="itin-chat-message-content">{m.text}</div>
+              </div>
+            ))}
+          </div>
+          <form onSubmit={handleSubmit} className="itin-chat-input-form">
+            <input
+              type="text"
+              placeholder={t('itinerary.chat.answerPlaceholder')}
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              disabled={isRefining}
+            />
+            <button type="submit" disabled={isRefining}>{t('itinerary.chat.send')}</button>
+          </form>
+          {refinementError && <p className="itin-chat-error">{refinementError.message || t('itinerary.chat.errorFallback')}</p>}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ItineraryChatPanel;

--- a/react-frontend/src/components/itinerary/ItineraryChatPanel.js
+++ b/react-frontend/src/components/itinerary/ItineraryChatPanel.js
@@ -16,12 +16,18 @@ const ItineraryChatPanel = ({ open, onToggle }) => {
   const { refinementMessages, isRefining, refinementError } = useSelector((state) => state.trip);
   const [inputValue, setInputValue] = useState('');
   const messagesRef = useRef(null);
+  const hasStartedRef = useRef(false);
 
   // Opens the confirm-then-modify conversation once, the first time this
   // panel mounts with nothing in it yet — a static local message, no
-  // backend round-trip.
+  // backend round-trip. Guarded by a ref (not just refinementMessages.length)
+  // because React.StrictMode (see src/index.js) double-invokes effects in
+  // dev — both invocations would otherwise still see an empty message list
+  // before the first dispatch's state update commits, producing two
+  // identical opening messages instead of one.
   useEffect(() => {
-    if (refinementMessages.length === 0) {
+    if (!hasStartedRef.current && refinementMessages.length === 0) {
+      hasStartedRef.current = true;
       dispatch(startRefinementConversation());
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/react-frontend/src/i18n/locales/en/translation.json
+++ b/react-frontend/src/i18n/locales/en/translation.json
@@ -120,7 +120,14 @@
     "day": "Day {{number}}",
     "loadingMap": "Loading map...",
     "arrivingVia": "Arriving via",
-    "departingFrom": "Departing from"
+    "departingFrom": "Departing from",
+    "chat": {
+      "title": "Refine your trip",
+      "toggle": "Toggle chat",
+      "answerPlaceholder": "Type your answer…",
+      "send": "Send",
+      "errorFallback": "Something went wrong. Please try again."
+    }
   },
   "footer": {
     "company": "Company",

--- a/react-frontend/src/i18n/locales/zh/translation.json
+++ b/react-frontend/src/i18n/locales/zh/translation.json
@@ -120,7 +120,14 @@
     "day": "第 {{number}} 天",
     "loadingMap": "地图加载中…",
     "arrivingVia": "抵达方式",
-    "departingFrom": "出发地点"
+    "departingFrom": "出发地点",
+    "chat": {
+      "title": "调整你的行程",
+      "toggle": "切换聊天面板",
+      "answerPlaceholder": "输入你的回答…",
+      "send": "发送",
+      "errorFallback": "出了点问题，请重试。"
+    }
   },
   "footer": {
     "company": "公司",

--- a/react-frontend/src/reducers/tripReducer.js
+++ b/react-frontend/src/reducers/tripReducer.js
@@ -4,7 +4,13 @@ import {
     SET_ITINERARY_LOADING,
     SET_ITINERARY,
     TRIP_ERRORS,
-    RESET_TRIP
+    RESET_TRIP,
+    ADD_REFINEMENT_MESSAGE,
+    SET_REFINEMENT_STAGE,
+    SET_REFINEMENT_LOADING,
+    REFINEMENT_ERRORS,
+    RESET_REFINEMENT,
+    UPDATE_ITINERARY
 } from "../actions/types";
 
 const initialState = {
@@ -12,7 +18,11 @@ const initialState = {
     messages: [],
     isGenerating: false,
     itinerary: null,
-    error: null
+    error: null,
+    refinementMessages: [],
+    isRefining: false,
+    refinementStage: null, // null | 'confirm' | 'editing' | 'done'
+    refinementError: null
 };
 
 export default function (state = initialState, action) {
@@ -46,6 +56,39 @@ export default function (state = initialState, action) {
             };
         case RESET_TRIP:
             return initialState;
+        case ADD_REFINEMENT_MESSAGE:
+            return {
+                ...state,
+                refinementMessages: [...state.refinementMessages, { id: state.refinementMessages.length + 1, ...action.payload }]
+            };
+        case SET_REFINEMENT_STAGE:
+            return {
+                ...state,
+                refinementStage: action.payload
+            };
+        case SET_REFINEMENT_LOADING:
+            return {
+                ...state,
+                isRefining: action.payload
+            };
+        case REFINEMENT_ERRORS:
+            return {
+                ...state,
+                refinementError: action.payload
+            };
+        case RESET_REFINEMENT:
+            return {
+                ...state,
+                refinementMessages: [],
+                isRefining: false,
+                refinementStage: null,
+                refinementError: null
+            };
+        case UPDATE_ITINERARY:
+            return {
+                ...state,
+                itinerary: action.payload
+            };
         default:
             return state;
     }


### PR DESCRIPTION
## Summary

Redesigns the Itinerary page to keep a chatbot present and open there too, per CLAUDE.md's "Redesign the Itinerary page around a persistent chatbot" backlog item — the chatbot previously only existed during trip intake and disappeared once the user reached `/itinerary`.

Depends on itjinshan/DS-Service#10 (adds the `/nlu/extract` fields this PR's edit-parsing relies on).

- **New docked chat panel** (`ItineraryChatPanel`), open by default, positioned as a third column alongside the existing itinerary list and map — not a floating help bubble. The existing draggable divider between list/map is completely untouched; the panel just subtracts its own width from the container via `calc()`.
- **Confirm-then-modify opening flow**: on arrival, a static local "want to change anything?" message (no backend call) — only the traveler's answer hits the server.
- **New backend** `POST /trip/refine` (`TBS/Node/APIs/trip.js`) — fully stateless, same pattern as `/intake`/`/generate`: the client resends the itinerary object each turn rather than this route addressing a saved Mongo trip.
- **New `replaceSpotInDay()`** in `itineraryPlanner.js` — the one architecturally-cheap edit operation: a single-spot swap within one day, with that day's `Route` recomputed. Deliberately does *not* support regenerating a whole day — `buildGreedyTour`/`splitIntoDays` run one continuous, order-dependent pass over every spot in the trip at once, so that isn't a well-defined cheap operation without reshuffling every other day too.
- Suppresses the existing floating `LLMChatBot` "Need help?" bubble specifically on `/itinerary` (it would visually collide with the new right-docked panel).
- i18n strings added for both `en`/`zh` (static chrome only — bot replies stay server-generated English, consistent with `/trip/intake`'s existing untranslated dynamic text).
- Leaves a comment hook (not an implementation) at the "no" branch of the confirm stage, marking where the already-logged accommodation-timing Bug's fix plugs in later — out of scope here.

**Two real bugs found and fixed along the way:**
- `Itinerary.js`'s `markers` was a `useState` lazy initializer that only ran once at mount — harmless before (itinerary never changed post-mount), but would leave map pins stale after a `/trip/refine` edit. Fixed with a `useEffect` resync on `itinerary`.
- `React.StrictMode`'s dev-mode double-invoke defeated the opening-message effect's `length === 0` guard, producing a duplicate opening chat message. Fixed with a ref guard.

## Test plan
- [x] Verified live in Chrome end-to-end: full intake → generate → chat panel opens with exactly one message, no floating bubble anywhere → answered "yes" → requested a real spot swap ("day 1, swap the palace museum for something more outdoorsy") → Day 1's card updated to a real DS-Service-sourced replacement (Summer Palace, with photo/rating/address) → the map marker moved to the new location and the view re-fit to include it → Day 2 and the rest of the itinerary left untouched.
- [x] Verified the existing draggable list/map divider still works unchanged with the chat panel open.
- [x] `eslint` clean on all changed/new frontend files (only pre-existing warnings remain); `node --check` clean on all changed backend files.
- [x] Regression: re-ran the homepage intake flow untouched — same behavior as before.