### PR TITLE
Fix Itinerary-page chat input requiring a scroll to the page bottom

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,8 +69,6 @@ Actual defects — existing behavior is wrong, not just missing. Prioritized ahe
 
 None currently open.
 
-- **The Itinerary-page chat panel's text input isn't visible without scrolling to the bottom of the whole page.** The chat input should be pinned to the bottom of the browser window at all times, the way `TripIntakePanel.js`'s own input already is — instead it's pinned to the bottom of `ItineraryChatPanel.js`'s own flex column (`.itin-chat-panel`/`.itin-chat-body`/`.itin-chat-input-form` in `ItineraryChatPanel.css`), which is itself correct in isolation, but that column's `height: 100vh` doesn't account for `NavBar`/`Footer` (`App.js`) both rendering unconditionally on every route, `/itinerary` included — `Itinerary.js`'s own root (`.itinerary-page`, `Itinerary.css`) is also `height: 100vh`. Stacked together, total page height is `NavBar height + 100vh + Footer height`, taller than the viewport, so the whole page (not just an internal panel) scrolls — pushing the chat input down below the fold along with the Footer, rather than the input staying fixed at the bottom of the window the way the rest of the Itinerary page's layout (list/map/divider) already correctly does via its own internal `overflow` handling. Likely fix: suppress `Footer` (and possibly `NavBar`, to match the intake page's own full-bleed treatment) on `/itinerary`, the same way `GlobalLLMChatBot` in `App.js` is already suppressed there — or make `.itinerary-page` account for `NavBar`'s actual rendered height instead of assuming `100vh` starts at the true top of the viewport.
-
 ### Backlog
 
 Backlog items surfaced while working on other plans, deliberately kept out of the active plan's PR scope. Pick these up as their own future PRs.

--- a/react-frontend/src/App.js
+++ b/react-frontend/src/App.js
@@ -38,6 +38,21 @@ const GlobalLLMChatBot = () => {
   return <LLMChatBot />;
 };
 
+// Itinerary.js renders a fixed-viewport, non-scrolling app view
+// (`.itinerary-page`, height: calc(100vh - navbar height) — see
+// Itinerary.css) with its own internal scroll regions (day list, map, chat
+// panel). Footer is marketing-page chrome with no purpose there, and its
+// extra height was previously pushing the whole page taller than the
+// viewport, forcing the ENTIRE page to scroll — including the chat panel's
+// input, which is otherwise correctly pinned to the bottom of its own
+// column — rather than staying fixed at the bottom of the window (see
+// CLAUDE.md's resolved chat-input-scroll bug for the full diagnosis).
+const GlobalFooter = () => {
+  const location = useLocation();
+  if (location.pathname === '/itinerary') return null;
+  return <Footer />;
+};
+
 
 // App class
 //
@@ -60,7 +75,7 @@ export default class App extends Component {
                 <Route path="/itinerary" element={<Itinerary />} />
               </Routes>
             </div>
-            <Footer />
+            <GlobalFooter />
             <GlobalLLMChatBot />
             </div>
         </Router>

--- a/react-frontend/src/components/itinerary/Itinerary.css
+++ b/react-frontend/src/components/itinerary/Itinerary.css
@@ -1,13 +1,21 @@
 .itinerary-page {
   display: flex;
   width: 100vw;
-  height: 100vh;
+  /* NavBar (App.js) is `position: sticky`, not `fixed` — it still occupies
+     its own 60px of document flow (see Navbar.css), so a flat 100vh here
+     made total page height taller than the viewport, forcing the whole
+     page to scroll instead of just this page's own internal regions (day
+     list, map, chat panel) — see CLAUDE.md's resolved chat-input-scroll
+     bug. Footer is also suppressed on this route (App.js) for the same
+     reason; NavBar itself stays, since it provides real navigation/login
+     state the itinerary page still wants. */
+  height: calc(100vh - 60px);
   overflow: hidden;
 }
 
 .container {
   display: flex;
-  height: 100vh;
+  height: 100%;
   position: relative;
   overflow: hidden;
 }

--- a/react-frontend/src/components/itinerary/ItineraryChatPanel.css
+++ b/react-frontend/src/components/itinerary/ItineraryChatPanel.css
@@ -1,5 +1,11 @@
 .itin-chat-panel {
-  height: 100vh;
+  /* Fills whatever height the parent .itinerary-page ends up being
+     (100vh minus NavBar's own height — see Itinerary.css), not a flat
+     100vh of its own — this is the fix for CLAUDE.md's resolved
+     chat-input-scroll bug: the input is pinned to the bottom of this
+     column via flexbox, but only works if the column itself never grows
+     taller than the actual space available in the viewport. */
+  height: 100%;
   flex-shrink: 0;
   border-left: 1px solid #e8eaed;
   background: #fff;


### PR DESCRIPTION
## Summary

Fixes the only open Bug in `CLAUDE.md`.

**Root cause**: `NavBar` is `position: sticky`, not `fixed`, so it still occupies its own 60px of document flow (`Navbar.css`). `Footer` also rendered unconditionally on every route, `/itinerary` included (`App.js`). Combined with `Itinerary.js`'s own `.itinerary-page { height: 100vh }` root, total page height exceeded the viewport (`NavBar height + 100vh + Footer height`) — so the *whole page* scrolled instead of just the chat panel's own internal message list, pushing the input (already correctly pinned to the bottom of its own flex column) below the fold along with the Footer.

**Fix**:
- Suppress `Footer` on `/itinerary` — same pattern already used for the floating `LLMChatBot` bubble there (`GlobalFooter`, mirroring the existing `GlobalLLMChatBot`).
- `.itinerary-page`'s height changes from a flat `100vh` to `calc(100vh - 60px)`, accounting for `NavBar`'s real height.
- `.container` and `.itin-chat-panel` (both previously their own redundant `height: 100vh`) now just `height: 100%`, so they fill whatever height the parent ends up being rather than each independently assuming the full viewport.

## Test plan
- [x] Verified in Chrome: `document.documentElement.scrollHeight` now exactly equals `window.innerHeight` on `/itinerary` — no page-level overflow at all.
- [x] Chat input stays visible at the bottom of the window immediately on load, and after the message list grows long enough to need its own internal scroll (tested with the accommodation-candidate list, which is one of the longer bot replies).
- [x] No console errors introduced; the divider/list/map layout is unaffected (untouched by this change).
- [x] `eslint` clean on `App.js` (only the pre-existing unrelated warning remains).