### PR TITLE
Log vague arrival/departure-point fuzzy-match bug

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ A throwaway QA account exists in the dev MongoDB for testing authenticated UI fl
 
 Actual defects — existing behavior is wrong, not just missing. Prioritized ahead of the feature backlog below.
 
-None currently open.
+- **Vague arrival/departure-point answers can fuzzy-match to an unrelated real place.** During intake, answering the "where will you be departing from" question with something like "same airport" (instead of repeating the airport's full name) got resolved via Amap's place-text-search to "SAME SIAM热啊东南亚餐厅(中关村领展广场店)" — a Thai restaurant whose name happens to start with "SAME" — rather than being recognized as referring back to the already-given arrival point, or re-prompting for a clearer answer. Surfaced while testing the Itinerary map's route-drawing feature (arrival/departure resolution, `Services/amapPlaces.js` / `APIs/trip.js`'s `resolvePlacePoint()`); not fixed as part of that work.
 
 ### Backlog
 


### PR DESCRIPTION
## Summary
- Logs a bug found while testing the Itinerary route-drawing feature (PR #32): answering the arrival/departure-point intake question with a vague phrase like "same airport" gets fuzzy-matched by Amap's place-text-search to an unrelated real business (a Thai restaurant named "SAME SIAM...") instead of resolving back to the already-given point or re-prompting for clarity.
- Doc-only, not fixed here.